### PR TITLE
stylish-haskell でコードを整形する

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -17,7 +17,15 @@ jobs:
           command: stack test
       - run:
           name: Run HLint
-          command: curl -sSL https://raw.github.com/ndmitchell/hlint/master/misc/run.sh | sh -s .
+          command: |
+            curl -sSL https://raw.github.com/ndmitchell/hlint/master/misc/run.sh \
+              | sh -s .
+      - run:
+          name: Run stylish-haskell
+          command: |
+            curl -sSL https://raw.github.com/jaspervdj/stylish-haskell/master/scripts/latest.sh \
+              | sh -s -- -i {app,src,test}/*.hs
+            git --no-pager diff --exit-code
       - save_cache:
           name: Cache Dependencies
           key: stack-{{ checksum "package.yaml" }}-{{ checksum "stack.yaml" }}

--- a/.stylish-haskell.yaml
+++ b/.stylish-haskell.yaml
@@ -1,0 +1,229 @@
+# stylish-haskell configuration file
+# ==================================
+
+# The stylish-haskell tool is mainly configured by specifying steps. These steps
+# are a list, so they have an order, and one specific step may appear more than
+# once (if needed). Each file is processed by these steps in the given order.
+steps:
+  # Convert some ASCII sequences to their Unicode equivalents. This is disabled
+  # by default.
+  # - unicode_syntax:
+  #     # In order to make this work, we also need to insert the UnicodeSyntax
+  #     # language pragma. If this flag is set to true, we insert it when it's
+  #     # not already present. You may want to disable it if you configure
+  #     # language extensions using some other method than pragmas. Default:
+  #     # true.
+  #     add_language_pragma: true
+
+  # Align the right hand side of some elements.  This is quite conservative
+  # and only applies to statements where each element occupies a single
+  # line.
+  - simple_align:
+      cases: true
+      top_level_patterns: true
+      records: true
+
+  # Import cleanup
+  - imports:
+      # There are different ways we can align names and lists.
+      #
+      # - global: Align the import names and import list throughout the entire
+      #   file.
+      #
+      # - file: Like global, but don't add padding when there are no qualified
+      #   imports in the file.
+      #
+      # - group: Only align the imports per group (a group is formed by adjacent
+      #   import lines).
+      #
+      # - none: Do not perform any alignment.
+      #
+      # Default: global.
+      align: global
+
+      # The following options affect only import list alignment.
+      #
+      # List align has following options:
+      #
+      # - after_alias: Import list is aligned with end of import including
+      #   'as' and 'hiding' keywords.
+      #
+      #   > import qualified Data.List      as List (concat, foldl, foldr, head,
+      #   >                                          init, last, length)
+      #
+      # - with_alias: Import list is aligned with start of alias or hiding.
+      #
+      #   > import qualified Data.List      as List (concat, foldl, foldr, head,
+      #   >                                 init, last, length)
+      #
+      # - new_line: Import list starts always on new line.
+      #
+      #   > import qualified Data.List      as List
+      #   >     (concat, foldl, foldr, head, init, last, length)
+      #
+      # Default: after_alias
+      list_align: after_alias
+
+      # Right-pad the module names to align imports in a group:
+      #
+      # - true: a little more readable
+      #
+      #   > import qualified Data.List       as List (concat, foldl, foldr,
+      #   >                                           init, last, length)
+      #   > import qualified Data.List.Extra as List (concat, foldl, foldr,
+      #   >                                           init, last, length)
+      #
+      # - false: diff-safe
+      #
+      #   > import qualified Data.List as List (concat, foldl, foldr, init,
+      #   >                                     last, length)
+      #   > import qualified Data.List.Extra as List (concat, foldl, foldr,
+      #   >                                           init, last, length)
+      #
+      # Default: true
+      pad_module_names: true
+
+      # Long list align style takes effect when import is too long. This is
+      # determined by 'columns' setting.
+      #
+      # - inline: This option will put as much specs on same line as possible.
+      #
+      # - new_line: Import list will start on new line.
+      #
+      # - new_line_multiline: Import list will start on new line when it's
+      #   short enough to fit to single line. Otherwise it'll be multiline.
+      #
+      # - multiline: One line per import list entry.
+      #   Type with constructor list acts like single import.
+      #
+      #   > import qualified Data.Map as M
+      #   >     ( empty
+      #   >     , singleton
+      #   >     , ...
+      #   >     , delete
+      #   >     )
+      #
+      # Default: inline
+      long_list_align: inline
+
+      # Align empty list (importing instances)
+      #
+      # Empty list align has following options
+      #
+      # - inherit: inherit list_align setting
+      #
+      # - right_after: () is right after the module name:
+      #
+      #   > import Vector.Instances ()
+      #
+      # Default: inherit
+      empty_list_align: inherit
+
+      # List padding determines indentation of import list on lines after import.
+      # This option affects 'long_list_align'.
+      #
+      # - <integer>: constant value
+      #
+      # - module_name: align under start of module name.
+      #   Useful for 'file' and 'group' align settings.
+      list_padding: 4
+
+      # Separate lists option affects formatting of import list for type
+      # or class. The only difference is single space between type and list
+      # of constructors, selectors and class functions.
+      #
+      # - true: There is single space between Foldable type and list of it's
+      #   functions.
+      #
+      #   > import Data.Foldable (Foldable (fold, foldl, foldMap))
+      #
+      # - false: There is no space between Foldable type and list of it's
+      #   functions.
+      #
+      #   > import Data.Foldable (Foldable(fold, foldl, foldMap))
+      #
+      # Default: true
+      separate_lists: true
+
+      # Space surround option affects formatting of import lists on a single
+      # line. The only difference is single space after the initial
+      # parenthesis and a single space before the terminal parenthesis.
+      #
+      # - true: There is single space associated with the enclosing
+      #   parenthesis.
+      #
+      #   > import Data.Foo ( foo )
+      #
+      # - false: There is no space associated with the enclosing parenthesis
+      #
+      #   > import Data.Foo (foo)
+      #
+      # Default: false
+      space_surround: false
+
+  # Language pragmas
+  - language_pragmas:
+      # We can generate different styles of language pragma lists.
+      #
+      # - vertical: Vertical-spaced language pragmas, one per line.
+      #
+      # - compact: A more compact style.
+      #
+      # - compact_line: Similar to compact, but wrap each line with
+      #   `{-#LANGUAGE #-}'.
+      #
+      # Default: vertical.
+      style: vertical
+
+      # Align affects alignment of closing pragma brackets.
+      #
+      # - true: Brackets are aligned in same column.
+      #
+      # - false: Brackets are not aligned together. There is only one space
+      #   between actual import and closing bracket.
+      #
+      # Default: true
+      align: true
+
+      # stylish-haskell can detect redundancy of some language pragmas. If this
+      # is set to true, it will remove those redundant pragmas. Default: true.
+      remove_redundant: true
+
+  # Replace tabs by spaces. This is disabled by default.
+  # - tabs:
+  #     # Number of spaces to use for each tab. Default: 8, as specified by the
+  #     # Haskell report.
+  #     spaces: 8
+
+  # Remove trailing whitespace
+  - trailing_whitespace: {}
+
+  # Squash multiple spaces between the left and right hand sides of some
+  # elements into single spaces. Basically, this undoes the effect of
+  # simple_align but is a bit less conservative.
+  # - squash: {}
+
+# A common setting is the number of columns (parts of) code will be wrapped
+# to. Different steps take this into account. Default: 80.
+columns: 80
+
+# By default, line endings are converted according to the OS. You can override
+# preferred format here.
+#
+# - native: Native newline format. CRLF on Windows, LF on other OSes.
+#
+# - lf: Convert to LF ("\n").
+#
+# - crlf: Convert to CRLF ("\r\n").
+#
+# Default: native.
+newline: native
+
+# Sometimes, language extensions are specified in a cabal file or from the
+# command line instead of using language pragmas in the file. stylish-haskell
+# needs to be aware of these, so it can parse the file correctly.
+#
+# No language extensions are enabled by default.
+# language_extensions:
+  # - TemplateHaskell
+  # - QuasiQuotes

--- a/README.md
+++ b/README.md
@@ -26,9 +26,16 @@ $ stack test --file-watch
 $ stack test --file-watch --test-arguments='--match FizzBuzz'
 ```
 
-## HLint の実行
+## Lint の実行
 
 ```console
 $ stack install hlint
 $ hlint .
+```
+
+## コードの整形
+
+```console
+$ stack install stylish-haskell
+$ stylish-haskell -i {app,src,test}/*.hs
 ```

--- a/app/Main.hs
+++ b/app/Main.hs
@@ -1,6 +1,6 @@
 module Main where
 
-import Lib
+import           Lib
 
 main :: IO ()
 main = someFunc

--- a/src/Bowling.hs
+++ b/src/Bowling.hs
@@ -20,9 +20,9 @@ toInt c = if c == '-'
     else digitToInt c
 
 toNonLastFrame :: String -> Frame
-toNonLastFrame ['X'] = StrikeFrame
+toNonLastFrame ['X']     = StrikeFrame
 toNonLastFrame [c1, '/'] = SpareFrame (toInt c1)
-toNonLastFrame [c1, c2] = OpenFrame (toInt c1) (toInt c2)
+toNonLastFrame [c1, c2]  = OpenFrame (toInt c1) (toInt c2)
 
 toInt' :: Char -> Int
 toInt' c = if c == 'X'

--- a/src/Bowling.hs
+++ b/src/Bowling.hs
@@ -20,9 +20,9 @@ toInt c = if c == '-'
     else digitToInt c
 
 toNonLastFrame :: String -> Frame
-toNonLastFrame ['X']     = StrikeFrame
+toNonLastFrame ['X'] = StrikeFrame
 toNonLastFrame [c1, '/'] = SpareFrame (toInt c1)
-toNonLastFrame [c1, c2]  = OpenFrame (toInt c1) (toInt c2)
+toNonLastFrame [c1, c2] = OpenFrame (toInt c1) (toInt c2)
 
 toInt' :: Char -> Int
 toInt' c = if c == 'X'

--- a/src/Bowling.hs
+++ b/src/Bowling.hs
@@ -1,6 +1,6 @@
 module Bowling where
 
-import Data.Char
+import           Data.Char
 
 
 -- http://codingdojo.org/kata/Bowling/
@@ -20,9 +20,9 @@ toInt c = if c == '-'
     else digitToInt c
 
 toNonLastFrame :: String -> Frame
-toNonLastFrame ['X'] = StrikeFrame
+toNonLastFrame ['X']     = StrikeFrame
 toNonLastFrame [c1, '/'] = SpareFrame (toInt c1)
-toNonLastFrame [c1, c2] = OpenFrame (toInt c1) (toInt c2)
+toNonLastFrame [c1, c2]  = OpenFrame (toInt c1) (toInt c2)
 
 toInt' :: Char -> Int
 toInt' c = if c == 'X'
@@ -30,10 +30,10 @@ toInt' c = if c == 'X'
     else toInt c
 
 toLastFrame :: String -> Frame
-toLastFrame [c1, c2] = LastFrame (toInt' c1) (toInt' c2) 0
+toLastFrame [c1, c2]      = LastFrame (toInt' c1) (toInt' c2) 0
 toLastFrame [c1, '/', c3] = LastFrame (toInt' c1) (10 - toInt' c1) (toInt' c3)
 toLastFrame [c1, c2, '/'] = LastFrame (toInt' c1) (toInt' c2) (10 - toInt' c2)
-toLastFrame [c1, c2, c3] = LastFrame (toInt' c1) (toInt' c2) (toInt' c3)
+toLastFrame [c1, c2, c3]  = LastFrame (toInt' c1) (toInt' c2) (toInt' c3)
 
 splitIntoFrames :: String -> [Frame]
 splitIntoFrames s =
@@ -44,10 +44,10 @@ splitIntoFrames s =
 type NextTwoThrow = (Int, Int)
 
 calcFrame :: Frame -> NextTwoThrow -> (Int, NextTwoThrow)
-calcFrame StrikeFrame (n1, n2) = (10 + n1 + n2, (10, n1))
+calcFrame StrikeFrame (n1, n2)    = (10 + n1 + n2, (10, n1))
 calcFrame (SpareFrame t1) (n1, _) = (10 + n1, (t1, 10 - t1))
-calcFrame (OpenFrame t1 t2) _ = (t1 + t2, (t1, t2))
-calcFrame (LastFrame t1 t2 t3) _ = (t1 + t2 + t3, (t1, t2))
+calcFrame (OpenFrame t1 t2) _     = (t1 + t2, (t1, t2))
+calcFrame (LastFrame t1 t2 t3) _  = (t1 + t2 + t3, (t1, t2))
 
 calcTotalScore :: [Frame] -> Int
 calcTotalScore = fst . foldr (

--- a/src/RomanNumerals.hs
+++ b/src/RomanNumerals.hs
@@ -7,10 +7,10 @@ module RomanNumerals
     , parseRoman
     ) where
 
-import Control.Monad
-import Data.Maybe
-import qualified Data.List as List
-import qualified Data.Map as Map
+import           Control.Monad
+import qualified Data.List     as List
+import qualified Data.Map      as Map
+import           Data.Maybe
 
 
 -- http://codingdojo.org/kata/RomanNumerals/

--- a/test/BowlingSpec.hs
+++ b/test/BowlingSpec.hs
@@ -1,7 +1,7 @@
 module BowlingSpec (spec) where
 
-import Test.Hspec
-import Bowling
+import           Bowling
+import           Test.Hspec
 
 {-# ANN module "HLint: ignore Redundant do" #-}
 

--- a/test/FizzBuzzSpec.hs
+++ b/test/FizzBuzzSpec.hs
@@ -1,8 +1,8 @@
 module FizzBuzzSpec (spec) where
 
-import Test.Hspec
-import System.IO.Silently
-import FizzBuzz
+import           FizzBuzz
+import           System.IO.Silently
+import           Test.Hspec
 
 {-# ANN module "HLint: ignore Redundant do" #-}
 

--- a/test/LibSpec.hs
+++ b/test/LibSpec.hs
@@ -1,8 +1,8 @@
 module LibSpec (spec) where
 
-import Test.Hspec
-import System.IO.Silently
-import Lib
+import           Lib
+import           System.IO.Silently
+import           Test.Hspec
 
 {-# ANN module "HLint: ignore Redundant do" #-}
 

--- a/test/RomanNumeralsSpec.hs
+++ b/test/RomanNumeralsSpec.hs
@@ -1,7 +1,7 @@
 module RomanNumeralsSpec (spec) where
 
-import Test.Hspec
-import RomanNumerals
+import           RomanNumerals
+import           Test.Hspec
 
 {-# ANN module "HLint: ignore Redundant do" #-}
 


### PR DESCRIPTION
Close #8 

stylish-haskell を入れて適用する。

- [jaspervdj/stylish-haskell: Haskell code prettifier](https://github.com/jaspervdj/stylish-haskell)
- [stylish-haskell - BIGMOON Haskeller's BLOG](https://haskell.e-bigmoon.com/stack/etc/stylish-haskell.html)
- [Haskellを書くときはstylish-haskellとhlintを使って労せずして綺麗なコードを書きましょう - ncaq](https://www.ncaq.net/2017/10/07/)